### PR TITLE
Python 3.12 changed recursion mechanism [1]

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -521,10 +521,10 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
 
     def test_recursion(self):
         old_limit = getrecursionlimit()
-        setrecursionlimit(200)
+        setrecursionlimit(100)
         try:
             obj = current = []
-            for _ in range(getrecursionlimit() * 2):
+            for _ in range(getrecursionlimit() * 30):
                 new_list = []
                 current.append(new_list)
                 current = new_list
@@ -532,7 +532,7 @@ class TestEncodeDecodePlain(TestCase):  # pylint: disable=too-many-public-method
             with self.assert_raises_regex(RuntimeError, 'recursion'):
                 self.bjddumpb(obj)
 
-            raw = ARRAY_START * (getrecursionlimit() * 2)
+            raw = ARRAY_START * (getrecursionlimit() * 30)
             with self.assert_raises_regex(RuntimeError, 'recursion'):
                 self.bjdloadb(raw)
         finally:


### PR DESCRIPTION
sys.setrecursionlimit() and sys.getrecursionlimit(). The recursion limit now applies only to Python code. Builtin functions do not use the recursion limit, but are protected by a different mechanism that prevents recursion from causing a virtual machine crash.

so increasing recursion limit as py-ubjson did [2] makes your package buildable.

[1] https://docs.python.org/3/whatsnew/3.12.html#sys
[2] https://sources.debian.org/src/py-ubjson/0.16.1-3/debian/patches/py12_recursion_PR19.diff/

Origin: https://bugs.debian.org/1058027#10